### PR TITLE
fix sign-splitting of unbounded values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "COBREXA"
 uuid = "babc4406-5200-4a30-9033-bf5ae714c842"
 authors = ["The developers of COBREXA.jl"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 AbstractFBCModels = "5a4f3dfa-1789-40f8-8221-69268c29937c"

--- a/src/builders/unsigned.jl
+++ b/src/builders/unsigned.jl
@@ -41,7 +41,9 @@ $(TYPEDSIGNATURES)
 A constraint tree of variables with positive contributions to the values in `cs`.
 """
 unsigned_positive_contribution_variables(cs::C.ConstraintTree) =
-    C.variables_for(c -> positive_bound_contribution(c.bound), cs)
+    C.variables_for(cs) do c
+        positive_bound_contribution(something(c.bound, C.Between(-Inf, Inf)))
+    end
 
 export unsigned_positive_contribution_variables
 
@@ -51,7 +53,10 @@ $(TYPEDSIGNATURES)
 A constraint tree of variables with negative contributions to the values in `cs`.
 """
 unsigned_negative_contribution_variables(cs::C.ConstraintTree) =
-    C.variables_for(c -> positive_bound_contribution(-c.bound), cs)
+    C.variables_for(cs) do c
+        positive_bound_contribution(-something(c.bound, C.Between(-Inf, Inf)))
+    end
+
 
 export unsigned_negative_contribution_variables
 


### PR DESCRIPTION
(to be released immediately)

Currently the sign splitters don't support the situation when there's a `nothing` left over somewhere in the bounds. Typically not the case but better have this handled.