### PR TITLE
use a parallel reduction for `isozyme_amount_variables`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "COBREXA"
 uuid = "babc4406-5200-4a30-9033-bf5ae714c842"
 authors = ["The developers of COBREXA.jl"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 AbstractFBCModels = "5a4f3dfa-1789-40f8-8221-69268c29937c"

--- a/src/builders/enzymes.jl
+++ b/src/builders/enzymes.jl
@@ -27,7 +27,7 @@ have isozymes, the second contains the isozyme IDs for each reaction flux.
 anything iterable that contains the isozyme IDs for the given reaction flux.
 Returning an empty iterable prevents allocating the subtree for the given flux.
 """
-isozyme_amount_variables(fluxes, flux_isozymes) = sum(
+isozyme_amount_variables(fluxes, flux_isozymes) = C.sum(
     (
         f^C.variables(keys = fis, bounds = C.Between(0, Inf)) for
         (f, fis) in ((f, flux_isozymes(f)) for f in fluxes) if


### PR DESCRIPTION
On iML1515 this speeds up the building of enzymatic constraints from ~10s to ~200ms.

Thanks @HettieC for the testcase.
