### PR TITLE
add a bit of documentation about missing kcats

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,11 +39,10 @@ for example in examples
 end
 
 # a helper for sourcing the documentation files from directories
-find_mds(path) =
-    joinpath.(
-        Ref(path),
-        filter(x -> endswith(x, ".md"), readdir(joinpath(@__DIR__, "src", path))),
-    )
+find_mds(path) = joinpath.(
+    Ref(path),
+    filter(x -> endswith(x, ".md"), readdir(joinpath(@__DIR__, "src", path))),
+)
 
 # build the docs
 makedocs(
@@ -80,7 +79,7 @@ makedocs(
 # extra fun: failing programs (such as plotting libraries) may generate core
 # dumps that contain the dumped environment strings, which in turn contain
 # github auth tokens. These certainly need to be avoided.
-examples_names = [n[begin:end-3] for n in examples_basenames]
+examples_names = [n[begin:(end-3)] for n in examples_basenames]
 ipynb_names = examples_names .* ".ipynb"
 examples_allowed_files = vcat("index.html", ipynb_names)
 @info "allowed files:" examples_allowed_files

--- a/docs/src/examples/05b-enzyme-constrained-models.jl
+++ b/docs/src/examples/05b-enzyme-constrained-models.jl
@@ -154,6 +154,9 @@ end
 #md # !!! tip "Turnover number units"
 #md #     Take care with the units of the turnover numbers. In literature they are usually reported in 1/s. However, flux units are typically mmol/gDW/h, suggesting to rescale the turnover numbers to 1/h in order to use the conventional flux units.
 
+#md # !!! tip "Missing turnover numbers"
+#md #     In case the turnover numbers are missing for a single direction of the reaction catalysis, we can use `nothing` instead of the turnover number. This will prevent generation of any enzyme capacity constraints for the corresponding reaction direction.
+
 # ## Enzyme molar masses
 
 # We also require the mass of each enzyme, to properly weight the contribution

--- a/docs/src/examples/07a-srba.jl
+++ b/docs/src/examples/07a-srba.jl
@@ -186,7 +186,7 @@ function with_translation_variables(ec_constraints::C.ConstraintTree)
     # exchange reactions in `ec_constraints`.)
     resources = C.variables(
         keys = Symbol.(
-            collect(union(amino_acids, keys(energy_stoichiometry), keys(biomass)))
+            collect(union(amino_acids, keys(energy_stoichiometry), keys(biomass))),
         ),
     )
     (cs, rs) =

--- a/src/analysis/sample.jl
+++ b/src/analysis/sample.jl
@@ -105,7 +105,7 @@ function sample_chain_achr(
                 sample[:, i] .+= lambda .* dir
             end
         end
-        result[:, n*(iter_idx-1)+1:iter_idx*n] .= sample
+        result[:, (n*(iter_idx-1)+1):(iter_idx*n)] .= sample
     end
 
     return collect(result')

--- a/src/frontend/balance.jl
+++ b/src/frontend/balance.jl
@@ -68,6 +68,7 @@ function flux_balance_constraints(
         :flux_stoichiometry^C.ConstraintTree(
             met => C.Constraint(
                 value = let i = stoiT.colptr[row_idx], e = stoiT.colptr[row_idx+1] - 1
+
                     C.LinearValue(idxs = stoiT.rowval[i:e], weights = stoiT.nzval[i:e])
                 end,
                 bound = C.EqualTo(b),

--- a/src/frontend/enzymes.jl
+++ b/src/frontend/enzymes.jl
@@ -21,6 +21,12 @@ A simple struct storing information about the isozyme composition, including
 subunit stoichiometry and turnover numbers. Use with
 [`enzyme_constrained_flux_balance_analysis`](@ref).
 
+If either of the turnover numbers is `nothing`, no bounds are added for that
+direction; i.e., the reaction is assumed not to require enzymes to proceed in
+that direction. If you want to disable the reaction in the given direction
+instead, either use `0` as a turnover number, or better put bounds directly on
+reaction flux.
+
 # Fields
 $(TYPEDFIELDS)
 """
@@ -32,11 +38,11 @@ Base.@kwdef mutable struct IsozymeT{T<:Real}
     gene_product_stoichiometry::Dict{String,T}
 
     "Turnover number for this isozyme catalyzing the forward direction of the
-    reaction."
+    reaction, or `nothing` if isozyme is not needed."
     kcat_forward::Maybe{T} = nothing
 
     "Turnover number for this isozyme catalyzing the reverse direction of the
-    reaction."
+    reaction, or `nothing` if isozyme is not needed."
     kcat_reverse::Maybe{T} = nothing
 end
 


### PR DESCRIPTION
refs https://github.com/COBREXA/COBREXA.jl/issues/93 , thanks @h-escoffier for report.

@stelmo I assume that if the kcat is missing in Isozyme, no bounds get generated (instead of blocking the reaction). Is that right? I'm not sure right now if this wouldn't instead block the reaction (or if it should block it :D ).

Thanks!

If all OK just merge pls.